### PR TITLE
Repeating events

### DIFF
--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -34,6 +34,9 @@ from evdev import ecodes, InputDevice, UInput
 from xdg import BaseDirectory
 import yaml
 
+DEFAULT_RATE = .1  # seconds
+repeat_tasks = {}
+
 
 @asyncio.coroutine
 def handle_events(input, output, remappings):
@@ -48,13 +51,77 @@ def handle_events(input, output, remappings):
                 output.syn()
 
 
+@asyncio.coroutine
+def repeat_event(event, rate, count, values, output):
+    if count == 0:
+        count = -1
+    while count is not 0:
+        count -= 1
+        for value in values:
+            event.value = value
+            output.write_event(event)
+            output.syn()
+        yield from asyncio.sleep(rate)
+
+
 def remap_event(output, event, remappings):
-    for code in remappings[event.code]:
-        event.code = code
-        output.write_event(event)
-    output.syn()
+    for remapping in remappings[event.code]:
+        original_code = event.code
+        event.code = remapping['code']
+        event.type = remapping.get('type', None) or event.type
+        values = remapping.get('value', None) or [event.value]
+        repeat = remapping.get('repeat', False)
+        if not repeat:
+            for value in values:
+                event.value = value
+                output.write_event(event)
+                output.syn()
+        else:
+            key_down = event.value is 1
+            key_up = event.value is 0
+            count = remapping.get('count', 0)
+            if not (key_up or key_down):
+                return
+
+            # count > 0  - ignore key-up events
+            # count is 0 - repeat until key-up occurs
+            ignore_key_up = count > 0
+
+            if ignore_key_up and key_up:
+                return
+            rate = remapping.get('rate', DEFAULT_RATE)
+            repeat_task = repeat_tasks.pop(original_code, None)
+            if repeat_task:
+                repeat_task.cancel()
+            if key_down:
+                repeat_tasks[original_code] = asyncio.ensure_future(
+                    repeat_event(event, rate, count, values, output))
 
 
+# Parses yaml config file and outputs normalized configuration.
+# Sample output:
+#  'devices': [{
+#    'input_fn': '',
+#    'input_name': '',
+#    'input_phys': '',
+#    'output_name': '',
+#    'remappings': {
+#      42: [{             # Matched key/button code
+#        'code': 30,      # Mapped key/button code
+#        'type': EV_REL,  # Overrides received event type [optional]
+#                         # Defaults to EV_KEY
+#        'value': [1, 0], # Overrides received event value [optional].
+#                         # If multiple values are specified they will
+#                         # be applied in sequence.
+#                         # Defaults to the value of received event.
+#        'repeat': True,  # Repeat key/button code [optional, default:False]
+#        'rate': 0.2,     # Repeat rate in seconds [optional, default:0.1]_
+#        'count': 3       # Repeat counter [optional, default:0]
+#                         # If count is 0 it will repeat until key/button is depressed
+#                         # If count > 0 it will repeat specified number of times
+#      }]
+#    }
+#  }]
 def load_config(config_override):
     conf_path = None
     if config_override is None:
@@ -72,16 +139,60 @@ def load_config(config_override):
     with open(conf_path.as_posix(), 'r') as fd:
         config = yaml.safe_load(fd)
         for device in config['devices']:
+            device['remappings'] = normalize_config(device['remappings'])
             device['remappings'] = resolve_ecodes(device['remappings'])
 
     return config
 
 
+# Converts general config schema
+# {'remappings': {
+#     'BTN_EXTRA': [
+#         'KEY_Z',
+#         'KEY_A',
+#         {'code': 'KEY_X', 'value': 1}
+#         {'code': 'KEY_Y', 'value': [1,0]]}
+#     ]
+# }}
+# into fixed format
+# {'remappings': {
+#     'BTN_EXTRA': [
+#         {'code': 'KEY_Z'},
+#         {'code': 'KEY_A'},
+#         {'code': 'KEY_X', 'value': [1]}
+#         {'code': 'KEY_Y', 'value': [1,0]]}
+#     ]
+# }}
+def normalize_config(remappings):
+    norm = {}
+    for key, mappings in remappings.items():
+        new_mappings = []
+        for mapping in mappings:
+            if type(mapping) is str:
+                new_mappings.append({'code': mapping})
+            else:
+                normalize_value(mapping)
+                new_mappings.append(mapping)
+        norm[key] = new_mappings
+    return norm
+
+
+def normalize_value(mapping):
+    value = mapping.get('value')
+    if value is None or type(value) is list:
+        return
+    mapping['value'] = [mapping['value']]
+
+
 def resolve_ecodes(by_name):
-    by_id = {}
-    for key, values in by_name.items():
-        by_id[ecodes.ecodes[key]] = [ecodes.ecodes[value] for value in values]
-    return by_id
+    def resolve_mapping(mapping):
+        if 'code' in mapping:
+            mapping['code'] = ecodes.ecodes[mapping['code']]
+        if 'type' in mapping:
+            mapping['type'] = ecodes.ecodes[mapping['type']]
+        return mapping
+    return {ecodes.ecodes[key]: list(map(resolve_mapping, mappings))
+            for key, mappings in by_name.items()}
 
 
 def find_input(device):
@@ -117,7 +228,10 @@ def register_device(device):
 
     remappings = device['remappings']
     extended = set(caps[ecodes.EV_KEY])
-    [extended.update(keys) for keys in remappings.values()]
+
+    def flatmap(lst):
+        return [l2 for l1 in lst for l2 in l1]
+    extended.update([remapping['code'] for remapping in flatmap(remappings.values())])
     caps[ecodes.EV_KEY] = list(extended)
 
     output = UInput(caps, name=device['output_name'])

--- a/examples/advanced_config.yaml
+++ b/examples/advanced_config.yaml
@@ -1,0 +1,45 @@
+devices:
+- input_name: 'Compx 2.4G Receiver'
+  input_fn: '/dev/input/event7'
+  output_name: remap-mouse
+  remappings:
+    # Map right button to double click
+    BTN_RIGHT:
+    - code: BTN_LEFT
+      value: [1, 0] # EV_KEY events - 1: key down, 0: key up
+      repeat: true
+      count: 2
+    # Map side buttons to vertical scroll
+    # Scroll event is repeated as long as button is kept pressed.
+    BTN_EXTRA:
+    - code: REL_WHEEL
+      type: EV_REL  # change event type
+      repeat: true
+      rate: 0.3  # repeat rate in seconds (defaults to 0.1)
+      value: 1   # EV_REL events - value signifies relative movement (ie. -3 could scroll down by three lines)
+    BTN_SIDE:
+    - code: REL_WHEEL
+      type: EV_REL
+      repeat: true
+      value: -1
+- input_name: 'AT Translated Set 2 keyboard'
+  input_fn: '/dev/input/event4'
+  output_name: remap-kbd
+  remappings:
+    # Emits predefined number of key strokes
+    KEY_LEFTSHIFT:
+    - code: KEY_A
+      value: [1,0]
+      repeat: true
+      count: 6
+    # Same as above
+    KEY_RIGHTSHIFT:
+    - code: KEY_A
+      value: [1,0,1,0]
+      repeat: true
+      count: 3
+    # Emits double key strokes as long as ALT is pressed
+    KEY_LEFTALT:
+    - code: KEY_A
+      value: [1,0,1,0]
+      repeat: true

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,0 +1,19 @@
+devices:
+- input_name: ''
+  input_fn: ''
+  output_name: ''
+  remappings:
+    KEY_A:
+    - KEY_A
+    KEY_B:
+    - code: KEY_A
+    KEY_C:
+    - code: KEY_A
+      value: 1
+    KEY_D:
+    - code: KEY_A
+      value: [1,2]
+    KEY_E:
+    - code: KEY_A
+      param1: p1
+      param2: p2

--- a/tests/load_config_test.py
+++ b/tests/load_config_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2017 Philip Langdale
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+import os
+import sys
+from evdev import ecodes
+import pprint
+
+spec_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append('{}/..'.format(spec_dir))
+from evdevremapkeys import load_config
+
+class TestLoadConfig(unittest.TestCase):
+    def test_supports_simple_notation(self):
+        mapping = remapping('config.yaml', ecodes.KEY_A)
+        self.assertEqual("[{'code': 30}]", str(mapping))
+    def test_supports_advanced_notation(self):
+        mapping = remapping('config.yaml', ecodes.KEY_B)
+        self.assertEqual("[{'code': 30}]", str(mapping))
+    def test_resolves_single_value(self):
+        mapping = remapping('config.yaml', ecodes.KEY_C)
+        self.assertEqual("[{code: 30,value: [1]}]", pretty(mapping))
+    def test_accepts_multiple_values(self):
+        mapping = remapping('config.yaml', ecodes.KEY_D)
+        self.assertEqual("[{code: 30,value: [1, 2]}]", pretty(mapping))
+    def test_accepts_other_parameters(self):
+        mapping = remapping('config.yaml', ecodes.KEY_E)
+        self.assertEqual("[{code: 30,param1: p1,param2: p2}]", pretty(mapping))
+
+def remapping(config_name, code):
+    config_path = '{}/{}'.format(spec_dir, config_name)
+    config = load_config(config_path)
+    return config['devices'][0]['remappings'].get(code)
+
+def pretty(mappings):
+    def prettymapping(mapping):
+        return '{'+','.join(['{}: {}'.format(key, mapping[key]) for key in sorted(mapping.keys())])+'}'
+    return '['+','.join([prettymapping(mapping) for mapping in mappings])+']'
+
+suite = unittest.TestLoader().loadTestsFromTestCase(TestLoadConfig)
+unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This is the implementation I suggested in #6. I've made it a little more general than initial proposal.
```yaml
- input_name: '...'
  remappings:
    BTN_EXTRA:
    - code: REL_WHEEL
      type: EV_REL        # Overrides received event type [optional]. Defaults to EV_KEY
      value: 1            # optional. Defaults to the value of received event.
      value: [1, ...]     # multiple values are supported; they will be applied in sequence.
      repeat: true/false  # optional, defaults to false
      count: xx           # number of repetitions (optional, defaults to 0).
                          # If count is 0 it will repeat until key/button is depressed which covers most use-cases I think
                          # If count > 0 it will repeat specified number of times 
      rate: 0.1           # Repeat rate in seconds [optional, default:0.1]_
```
These changes should be backwards compatible with initial config format.
