### PR TITLE
Adding two new features

### DIFF
--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -129,7 +129,7 @@ def remap_event(output, event, remappings):
 #                         # Defaults to the value of received event.
 #        'repeat': True,  # Repeat key/button code [optional, default:False]
 #        'delay': True,   # Delay key/button output [optional, default:False]
-#        'rate': 0.2,     # Repeat rate in seconds [optional, default:0.1]_
+#        'rate': 0.2,     # Repeat rate in seconds [optional, default:0.1]
 #        'count': 3       # Repeat/Delay counter [optional, default:0]
 #                         # For repeat:
 #                         # If count is 0 it will repeat until key/button is depressed

--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -128,10 +128,15 @@ def remap_event(output, event, remappings):
 #                         # be applied in sequence.
 #                         # Defaults to the value of received event.
 #        'repeat': True,  # Repeat key/button code [optional, default:False]
+#        'delay': True,   # Delay key/button output [optional, default:False]
 #        'rate': 0.2,     # Repeat rate in seconds [optional, default:0.1]_
-#        'count': 3       # Repeat counter [optional, default:0]
+#        'count': 3       # Repeat/Delay counter [optional, default:0]
+#                         # For repeat:
 #                         # If count is 0 it will repeat until key/button is depressed
 #                         # If count > 0 it will repeat specified number of times
+#                         # For delay:
+#                         # Will suppress key/button output x times before execution [x = count]
+#                         # Ex: count = 1 will execute key press every other time
 #      }]
 #    }
 #  }]

--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -272,6 +272,28 @@ def list_devices():
     for device in reversed(devices):
         print('%s:\t"%s" | "%s"' % (device.fn, device.phys, device.name))
 
+def read_events(device):
+    devices = evdev.list_devices()
+    device = '/dev/input/event' + str(device)
+    if device in devices:
+        device = evdev.InputDevice(device)
+        print(device)
+        print("To stop, press Ctrl-C")
+
+        for event in device.read_loop():
+            try:
+                if event.type == evdev.ecodes.EV_KEY:
+                    categorized = evdev.categorize(event)
+                    if categorized.keystate == 1:
+                        print("Key pressed: %s (%s)" % (categorized.keycode, categorized.scancode))
+            except KeyError:
+                if event.value:
+                    print("Unknown key (%s) has been pressed." % event.code)
+                else:
+                    print("Unknown key (%s) has been released." % event.code)
+    else:
+        print("Device not found. \nPlease use --list-devices option to view a list of available devices.")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Re-bind keys for input devices')
@@ -281,9 +303,14 @@ if __name__ == '__main__':
                         help='Config file that overrides default location')
     parser.add_argument('-l', '--list-devices', action='store_true',
                         help='List input devices by name and physical address')
+    parser.add_argument('-e', '--read-events', metavar='EVENT_NUM',
+                        help='Read events from a certain input device')
+
     args = parser.parse_args()
     if args.list_devices:
         list_devices()
+    elif args.read_events:
+        read_events(args.read_events)
     elif args.daemon:
         with daemon.DaemonContext():
             run_loop(args)

--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -36,7 +36,7 @@ import yaml
 
 DEFAULT_RATE = .1  # seconds
 repeat_tasks = {}
-
+remapped_tasks = {}
 
 @asyncio.coroutine
 def handle_events(input, output, remappings):
@@ -71,7 +71,8 @@ def remap_event(output, event, remappings):
         event.type = remapping.get('type', None) or event.type
         values = remapping.get('value', None) or [event.value]
         repeat = remapping.get('repeat', False)
-        if not repeat:
+        delay = remapping.get('delay', False)
+        if not repeat and not delay:
             for value in values:
                 event.value = value
                 output.write_event(event)
@@ -80,22 +81,34 @@ def remap_event(output, event, remappings):
             key_down = event.value is 1
             key_up = event.value is 0
             count = remapping.get('count', 0)
+
             if not (key_up or key_down):
                 return
+            if delay:
+                if original_code not in remapped_tasks or remapped_tasks[original_code] == 0:
+                    if key_down:
+                        remapped_tasks[original_code] = count
+                else:
+                    if key_down:
+                        remapped_tasks[original_code] -= 1
 
-            # count > 0  - ignore key-up events
-            # count is 0 - repeat until key-up occurs
-            ignore_key_up = count > 0
+                if remapped_tasks[original_code] == count:
+                    output.write_event(event)
+                    output.syn()
+            elif repeat:
+                # count > 0  - ignore key-up events
+                # count is 0 - repeat until key-up occurs
+                ignore_key_up = count > 0
 
-            if ignore_key_up and key_up:
-                return
-            rate = remapping.get('rate', DEFAULT_RATE)
-            repeat_task = repeat_tasks.pop(original_code, None)
-            if repeat_task:
-                repeat_task.cancel()
-            if key_down:
-                repeat_tasks[original_code] = asyncio.ensure_future(
-                    repeat_event(event, rate, count, values, output))
+                if ignore_key_up and key_up:
+                    return
+                rate = remapping.get('rate', DEFAULT_RATE)
+                repeat_task = repeat_tasks.pop(original_code, None)
+                if repeat_task:
+                    repeat_task.cancel()
+                if key_down:
+                    repeat_tasks[original_code] = asyncio.ensure_future(
+                        repeat_event(event, rate, count, values, output))
 
 
 # Parses yaml config file and outputs normalized configuration.

--- a/evdevremapkeys.py
+++ b/evdevremapkeys.py
@@ -308,7 +308,9 @@ def read_events(req_device):
             if event.type == evdev.ecodes.EV_KEY:
                 categorized = evdev.categorize(event)
                 if categorized.keystate == 1:
-                    print("Key pressed: %s (%s)" % (categorized.keycode, categorized.scancode))
+                    keycode = categorized.keycode if type(categorized.keycode) is str else \
+                            " | ".join(categorized.keycode)
+                    print("Key pressed: %s (%s)" % (keycode, categorized.scancode))
         except KeyError:
             if event.value:
                 print("Unknown key (%s) has been pressed." % event.code)

--- a/examples/advanced_config.yaml
+++ b/examples/advanced_config.yaml
@@ -22,6 +22,10 @@ devices:
       type: EV_REL
       repeat: true
       value: -1
+    REL_WHEEL:
+    - code: BTN_RIGHT
+      delay: true
+      count: 4   # send BTN_RIGHT and then skip the next 4 events
 - input_name: 'AT Translated Set 2 keyboard'
   input_fn: '/dev/input/event4'
   output_name: remap-kbd


### PR DESCRIPTION
Hi,
I've been tweaking your script a little bit and was hoping you'd like to include my changes in your repo.

1.  `--read-events` switch which eliminates the need to use tools like `evtest` to find out key codes for the config file.
2. Adding a delay option as we discussed. I hope you'd approve of my method. I tried to make it as close as possible to the already implemented `repeat` feature, so I also made them share the same umbrella under the `else` part in `remap_event()`.

I'd like to investigate a further improvement to allow for multiple key remappings with a delay. For example, remap a wheel action to `alt-tab`.
Right now I got it working only for one remapping instance (with a couple of tweaks):
```yaml
    KEY_VOLUMEUP: # 4 swipe up
    - code: KEY_LEFTALT
      delay: true
      count: 4
    - code: KEY_TAB
      delay: true
      count: 4
```
There are two main problems with this:

1. For some reason, `original_code` in `remap_event()` doesn't always contain the same code (for `KEY_VOLUMEUP` in the above case), so I'm not sure how to handle multiple remappings of this kind. My plan was using a dictionary that looks like that `{'original_code': {'code1': count, 'code2': count}}` but that's impossible without knowing the original code...
2. Configuration is somewhat clumsy, would prefer something like `code: ['KEY_LEFTALT', 'KEY_TAB']`, but this would require some changes to the `resolve_ecodes` function, and I'm not sure you'll like that.

If you think we should discuss this somewhere else, please let me know.

Thanks in advance!