### PR TITLE
Implement long-press mappings

### DIFF
--- a/examples/long_press_config.yaml
+++ b/examples/long_press_config.yaml
@@ -1,0 +1,72 @@
+
+# Long-press configuration
+#    BTN_RIGHT:               # key to be mapped
+#    - code: BTN_RIGHT        # short-press key
+#      repeat: true           # whether to repeat short-press key (optional; defaults to false)
+#      rate: .1               # short-press repeat rate (optional; defaults to 0.1 seconds)
+#      count: 2               # short-press count; must be greater than 0 (optional; defaults to 1)
+#      long_press:            #
+#        code: BTN_LEFT       # long-press key
+#        duration: .2         # seconds to wait before considering it a long-press (optional; defaults to 0.2 seconds)
+#        repeat: true         # whether to repreat long-press key (optional; defaults to false)
+#        rate: .1             # long-press repeat rate (optional; defaults to 0.1 seconds)
+#        count: 2             # long-press count; if 0 it repeats untill key is depressed (optional; defaults to 0)
+
+devices:
+- input_name: 'Compx 2.4G Receiver'
+  input_phys: 'usb-0000:00:14.0-3/input1'
+  output_name: remap-mouse
+  remappings:
+    # Map right button to double click when long pressed
+    BTN_RIGHT:
+    - code: BTN_RIGHT
+      long_press:
+        duration: .2
+        code: BTN_LEFT
+        repeat: true
+        rate: .1
+        count: 2
+    # Map middle button to 'right click' when long pressed and double click when short pressed
+    BTN_MIDDLE:
+    - code: BTN_LEFT
+      long_press:
+        duration: .2
+        code: BTN_RIGHT
+      repeat: true
+      rate: .1
+      count: 2
+
+    # Map side buttons to vertical scroll
+    # Scroll event is repeated as long as button is kept pressed.
+    # Original behaviour (back/forward) is kept for short click.
+    BTN_SIDE:
+    - code: BTN_SIDE
+      long_press:
+        duration: .15
+        value: [-1]
+        code: REL_WHEEL
+        type: EV_REL
+        repeat: true
+    BTN_EXTRA:
+    - code: BTN_EXTRA
+      long_press:
+        duration: .15
+        value: [1]
+        code: REL_WHEEL
+        type: EV_REL
+        repeat: true
+- input_name: 'AT Translated Set 2 keyboard'
+  input_phys: 'isa0060/serio0/input0'
+  output_name: remap-asus-kb
+  remappings:
+    # Map F1 to 'copy' when short pressed. Original behaviour remains on long press.
+    KEY_F1:
+      - code: [KEY_LEFTCTRL, KEY_C]
+        long_press:
+          code: KEY_F1
+    # Map TAB to 'paste' when long pressed. Original behaviour remains on short press.
+    KEY_TAB:
+      - code: KEY_TAB
+        long_press:
+          code: [KEY_LEFTCTRL, KEY_V]
+

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -17,3 +17,18 @@ devices:
     - code: KEY_A
       param1: p1
       param2: p2
+    KEY_F:
+    - code: KEY_A
+      type: EV_REL
+      complex_param:
+        duration: .2
+        value: 1
+        complex_param2:
+          duration: .2
+          value: 1
+          code: [BTN_LEFT, BTN_RIGHT]
+          repeat: true
+          type: EV_REL
+        code: BTN_LEFT
+        repeat: true
+        type: EV_REL

--- a/tests/load_config_test.py
+++ b/tests/load_config_test.py
@@ -47,6 +47,12 @@ class TestLoadConfig(unittest.TestCase):
     def test_accepts_other_parameters(self):
         mapping = remapping('config.yaml', ecodes.KEY_E)
         self.assertEqual("[{code: 30,param1: p1,param2: p2}]", pretty(mapping))
+    def test_accepts_complex_parameters(self):
+        mapping = remapping('config.yaml', ecodes.KEY_F)
+        self.assertEqual("[{code: 30,complex_param: {'duration': 0.2, 'value': [1], "
+                         "'complex_param2': {'duration': 0.2, 'value': [1], 'code': [272, 273], "
+                         "'repeat': True, 'type': 2}, 'code': 272, 'repeat': True, "
+                         "'type': 2},type: 2}]", pretty(mapping))
 
 def remapping(config_name, code):
     config_path = '{}/{}'.format(spec_dir, config_name)


### PR DESCRIPTION
This PR implements long-press mappings.
Following example maps right mouse button to double-click when long pressed.
```yaml
BTN_RIGHT:               # key to be mapped
- code: BTN_RIGHT        # short-press key
  repeat: true           # whether to repeat short-press key (optional; defaults to false)
  rate: .1               # short-press repeat rate (optional; defaults to 0.1 seconds)
  count: 2               # short-press count; must be greater than 0 (optional; defaults to 1)
  long_press:            #
    code: BTN_LEFT       # long-press key
    duration: .2         # seconds to wait before considering it a long-press (optional; defaults to 0.2 seconds)
    repeat: true         # whether to repreat long-press key (optional; defaults to false)
    rate: .1             # long-press repeat rate (optional; defaults to 0.1 seconds)
    count: 2             # long-press count; if 0 it repeats untill key is depressed (optional; defaults to 0)
```
Changes in this PR should be backward-compatible with existing config files.
