### PR TITLE
Added option to allow failed lookup of device

### DIFF
--- a/evdevremapkeys/evdevremapkeys.py
+++ b/evdevremapkeys/evdevremapkeys.py
@@ -269,7 +269,13 @@ def shutdown(loop):
 def run_loop(args):
     config = load_config(args.config_file)
     for device in config['devices']:
-        register_device(device)
+        if args.allow_invalid:
+            try:
+                register_device(device)
+            except NameError:
+                pass
+        else:
+            register_device(device)
 
     loop = asyncio.get_event_loop()
     loop.add_signal_handler(signal.SIGTERM,
@@ -328,7 +334,7 @@ def main():
                         help='List input devices by name and physical address')
     parser.add_argument('-e', '--read-events', metavar='EVENT_ID',
                         help='Read events from an input device by either name, physical address or number.')
-
+    parser.add_argument('-a', '--allow-invalid', action='store_true')
     args = parser.parse_args()
     if args.list_devices:
         print("\n".join(['%s:\t"%s" | "%s' % (fn, phys, name) for (fn, phys, name) in list_devices()]))

--- a/evdevremapkeys/evdevremapkeys.py
+++ b/evdevremapkeys/evdevremapkeys.py
@@ -334,7 +334,8 @@ def main():
                         help='List input devices by name and physical address')
     parser.add_argument('-e', '--read-events', metavar='EVENT_ID',
                         help='Read events from an input device by either name, physical address or number.')
-    parser.add_argument('-a', '--allow-invalid', action='store_true')
+    parser.add_argument('-a', '--allow-invalid', action='store_true',
+                        help='Skip invalid device names instead of crashing')
     args = parser.parse_args()
     if args.list_devices:
         print("\n".join(['%s:\t"%s" | "%s' % (fn, phys, name) for (fn, phys, name) in list_devices()]))


### PR DESCRIPTION
I was having difficulties getting this to work in a startup script when a device in my .yaml config wasn't actually connected. This gives you the option to allow this to happen and continue without crashing.