### PR TITLE
Add the ability to configure modifier keys

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -17,3 +17,21 @@ devices:
     - code: KEY_A
       param1: p1
       param2: p2
+    KEY_Z:
+    - modifier_group: mod1
+  modifier_groups:
+    mod1:
+      KEY_A:
+      - KEY_F
+      KEY_B:
+      - code: KEY_F
+      KEY_C:
+      - code: KEY_F
+        value: 2
+      KEY_D:
+      - code: KEY_F
+        value: [1,3]
+      KEY_E:
+      - code: KEY_F
+        param3: p1
+        param4: p2

--- a/tests/load_config_test.py
+++ b/tests/load_config_test.py
@@ -47,11 +47,34 @@ class TestLoadConfig(unittest.TestCase):
     def test_accepts_other_parameters(self):
         mapping = remapping('config.yaml', ecodes.KEY_E)
         self.assertEqual("[{code: 30,param1: p1,param2: p2}]", pretty(mapping))
+    def test_accepts_modifier(self):
+        mapping = remapping('config.yaml', ecodes.KEY_Z)
+        self.assertEqual("[{modifier_group: mod1}]", pretty(mapping))
+    def test_mod_group_supports_simple_notation(self):
+        mapping = modified_remapping('config.yaml', ecodes.KEY_A)
+        self.assertEqual("[{code: 33}]", pretty(mapping))
+    def test_mod_group_supports_advanced_notation(self):
+        mapping = modified_remapping('config.yaml', ecodes.KEY_B)
+        self.assertEqual("[{'code': 33}]", str(mapping))
+    def test_mod_group_resolves_single_value(self):
+        mapping = modified_remapping('config.yaml', ecodes.KEY_C)
+        self.assertEqual("[{code: 33,value: [2]}]", pretty(mapping))
+    def test_mod_group_accepts_multiple_values(self):
+        mapping = modified_remapping('config.yaml', ecodes.KEY_D)
+        self.assertEqual("[{code: 33,value: [1, 3]}]", pretty(mapping))
+    def test_mod_group_accepts_other_parameters(self):
+        mapping = modified_remapping('config.yaml', ecodes.KEY_E)
+        self.assertEqual("[{code: 33,param3: p1,param4: p2}]", pretty(mapping))
 
 def remapping(config_name, code):
     config_path = '{}/{}'.format(spec_dir, config_name)
     config = load_config(config_path)
     return config['devices'][0]['remappings'].get(code)
+
+def modified_remapping(config_name, code):
+    config_path = '{}/{}'.format(spec_dir, config_name)
+    config = load_config(config_path)
+    return config['devices'][0]['modifier_groups']['mod1'].get(code)
 
 def pretty(mappings):
     def prettymapping(mapping):


### PR DESCRIPTION
The goal of this PR is not to provide true chording capability
(which has been raised in one of the issues) but to provide discrete
groups of rebinds based on one key press. The inspiration for it
was to provide similar functionality to the (now defunct) pystromo.

This is done by adding three new keys to the config file:

A key can now be bound to a modifier group:

    KEY_Z:
    - modifier_group: chat_hotkeys

The modifier group can be defined in a new section:

    modifier_groups:
      chat_hotkeys:
        KEY_Q:
        - KEY_W

Each modifier group looks just like `remappings`

PS: I do not write python that often, if I have made any
errors in style or convention, please let me know.
