### PR TITLE
Fix remapping values bleeding from last entry, set input props same as the original device.

### DIFF
--- a/evdevremapkeys/evdevremapkeys.py
+++ b/evdevremapkeys/evdevremapkeys.py
@@ -87,11 +87,13 @@ def repeat_event(event, rate, count, values, output):
 
 
 def remap_event(output, event, event_remapping):
+    original_type = event.type
+    original_value = event.value
+    original_code = event.code
     for remapping in event_remapping:
-        original_code = event.code
         event.code = remapping['code']
-        event.type = remapping.get('type', None) or event.type
-        values = remapping.get('value', None) or [event.value]
+        event.type = remapping.get('type', None) or original_type
+        values = remapping.get('value', None) or [original_value]
         repeat = remapping.get('repeat', False)
         delay = remapping.get('delay', False)
         if not repeat and not delay:
@@ -307,7 +309,7 @@ def register_device(device):
                 extended.update([remapping['code']])
 
     caps[ecodes.EV_KEY] = list(extended)
-    output = UInput(caps, name=device['output_name'])
+    output = UInput(caps, input_props=input.input_props(), name=device['output_name'])
     print('Registered: %s, %s, %s' % (input.name, input.path, input.phys), flush=True)
     future = asyncio.ensure_future(
         handle_events(input, output, remappings, modifier_groups))


### PR DESCRIPTION
I ran into a bug with this config,
```
devices:
- input_name: 'ELAN9038:00 04F3:261A Pen'
  output_name: remap-pen
  remappings:
    'BTN_TOOL_RUBBER': [
         {'code': 'BTN_TOOL_PEN', 'value': 0},
         {'code': 'BTN_TOOL_RUBBER'}
    ]
```
where the `BTN_TOOL_PEN` entry would set `event.value` to 0 and the following entry would not actually set `BTN_TOOL_RUBBER` to the original event value but would keep it 0. The intended effect was to always unset BTN_TOOL_PEN if BTN_TOOL_RUBBER is ever set or unset. I also fixed another issue where device properties wouldn't be set, which was needed since this device is a stylus pen for a touchscreen and it had `INPUT_PROP_DIRECT` set.