### PR TITLE
resolve module not found error when running tests

### DIFF
--- a/tests/load_config_test.py
+++ b/tests/load_config_test.py
@@ -21,12 +21,16 @@
 # SOFTWARE.
 
 import io
+import os
 import pytest
+import sys
 import yaml
 
 from evdev import ecodes
-from evdevremapkeys.evdevremapkeys import parse_config
 
+spec_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append('{}/..'.format(spec_dir))
+from evdevremapkeys.evdevremapkeys import parse_config
 
 sample_config_data = '''
 devices:


### PR DESCRIPTION
When checking out and running tests on a clean system, tests fail with `ModuleNotFoundError`. This change corrects that problem