### PR TITLE
reverse input list for finding device by name

### DIFF
--- a/evdevremapkeys/evdevremapkeys.py
+++ b/evdevremapkeys/evdevremapkeys.py
@@ -258,7 +258,7 @@ def find_input(device):
         raise NameError('Devices must be identified by at least one ' +
                         'of "input_name", "input_phys", or "input_fn"')
 
-    devices = [InputDevice(fn) for fn in evdev.list_devices()]
+    devices = [InputDevice(fn) for fn in reversed(evdev.list_devices())]
     for input in devices:
         if name is not None and input.name != name:
             continue


### PR DESCRIPTION
I assume this may be a long-shot for actually getting merged, but worth a try to me and maybe it can help someone else.

The device that I primarily use evdevremapkeys for is an old Nostromo N52 Speedpad. It seems to present itself to the system as two seperate input devices. I only intend to remap the keyboard type functionality, and leave the mouse functionality alone so it behaves in the default manner. 

Without this change if I specify name only it seems to find the "incorrect" one of the two inputs and therefore does not remap the keys.

reversing this list allows me to specify only the device name in my config.yml:
```
- input_name: 'Honey Bee  Nostromo SpeedPad2 '
  output_name: remap-kbd
  remappings:
```
And it will get properly registered no matter which port it's plugged in to.

Without the change I need to specify `input_phys` in order to target the correct one of the two inputs. This works but the correct value changes depending on which USB port / hub port my device is plugged in to, which then requires changing the config any time I move it to a different port.