### PR TITLE
ModuleNotFoundError: No module named 'imp' when building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
 
 [options.extras_require]
 binary =
-    PyInstaller==4.2
+    PyInstaller==6.11.0
     staticx>=0.9.1
 test =
     flake8


### PR DESCRIPTION
When building with python 3.12.3 I've got: `ModuleNotFoundError: No module named 'imp'`.

It turned out that [the `imp` module is deprecated in favour of importlib and slated for removal in Python 3.12](https://stackoverflow.com/questions/77401730/modulenotfounderror-no-module-named-imp)

It has been fixed in recent PyInstaller, so I've just dumped it version to lates in `setup.cfg` and I hope that it won't break anything on older Pythons. 

Full traceback (I've added set -o xtrace to print commands):
```
+ pyinstaller --onefile ./evdevremapkeys/evdevremapkeys.py
Traceback (most recent call last):
  File "/home/q84fh/bin/evdevremapkeys/venv/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/PyInstaller/__main__.py", line 81, in run
    import PyInstaller.building.build_main
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/PyInstaller/building/build_main.py", line 35, in <module>
    from ..depend import bindepend
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/PyInstaller/depend/bindepend.py", line 30, in <module>
    from . import dylib, utils
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/PyInstaller/depend/utils.py", line 28, in <module>
    from ..lib.modulegraph import util, modulegraph
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/PyInstaller/lib/modulegraph/util.py", line 8, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
+ mkdir bundle
+ staticx ./dist/evdevremapkeys ./bundle/evdevremapkeys
Traceback (most recent call last):
  File "/home/q84fh/bin/evdevremapkeys/venv/bin/staticx", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/__main__.py", line 49, in main
    generate(args.prog, args.output,
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/api.py", line 328, in generate
    gen.generate(output=output)
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/api.py", line 115, in generate
    self._get_bootloader()
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/api.py", line 85, in _get_bootloader
    prog_mach = get_machine(self.orig_prog)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/elf.py", line 324, in get_machine
    with open_elf(path) as elf:
         ^^^^^^^^^^^^^^
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/elf.py", line 318, in open_elf
    return ELFFileX.open(path, mode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/q84fh/bin/evdevremapkeys/venv/lib/python3.12/site-packages/staticx/elf.py", line 263, in open
    return cls(open(path, mode), path=path)
               ^^^^^^^^^^^^^^^^
```